### PR TITLE
Improve subpackage CI rpm build process and error handling

### DIFF
--- a/.github/workflows/check-subpackages.yml
+++ b/.github/workflows/check-subpackages.yml
@@ -19,15 +19,24 @@ jobs:
 
       - name: Run make for each subsystem
         run: |
+          subsystem_build_failures=()
           for dir in subsystems/*; do
-            if [ -d "$dir" ]; then
-              subsystem=$(basename "$dir")
-              echo "Running make for $subsystem..."
-              make TARGETS=$subsystem subpackages
-              if [ $? -ne 0 ]; then
-                echo "❌ Make failed for $subsystem" >&2
-                exit 1
+              if [ -d "$dir" ]; then
+                  subsystem=$(basename "$dir")
+                  echo "Running make for $subsystem..."
+                  make TARGETS=$subsystem subpackages
+                  if [ $? -ne 0 ]; then
+                      subsystem_build_failures+=("$subsystem")
+                      echo "❌ Make failed for $subsystem" >&2
+                  fi
               fi
-            fi
           done
+          if (( ${#subsystem_build_failures[@]} == 0 )); then
+              echo "✅ All subsystems built successfully"; \
+              exit 0;
+          else
+              echo "❌ The following subsystems failed to build: "; 
+              echo -e "\t${subsystem_build_failures[@]}" | tr ' ' ', '; 
+              exit 1; 
+          fi
 

--- a/subsystems/dvb/Makefile
+++ b/subsystems/dvb/Makefile
@@ -2,26 +2,32 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_DVB ?= ${ROOTDIR}/rpm/dvb/dvb.spec
+PACKAGE_NAME = qm-mount-bind-dvb
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM dvb package
 	cd $(ROOTDIR) && tar cvz \
 		--dereference \
-		--transform s/qm/qm-dvb-${VERSION}/ \
-		-f /tmp/qm-dvb-${VERSION}.tar.gz \
+		--transform s/qm/${NV}/ \
+		-f /tmp/${NV}.tar.gz \
 		../qm/README.md \
 		../qm/SECURITY.md \
 		../qm/LICENSE \
 		../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_dvb.conf
-	cd $(ROOTDIR) && mv /tmp/qm-dvb-${VERSION}.tar.gz ./rpm
+	cd $(ROOTDIR) && mv /tmp/${NV}.tar.gz ./rpm
 
 .PHONY: dvb
 dvb: dist ##             - Creates a local RPM package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cd $(ROOTDIR) && cp ./rpm/qm-dvb-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd $(ROOTDIR) && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_DVB}
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi
 

--- a/subsystems/input/Makefile
+++ b/subsystems/input/Makefile
@@ -2,25 +2,31 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_INPUT ?= ${ROOTDIR}/rpm/input/input.spec
+PACKAGE_NAME = qm-mount-bind-input
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM input package
 	cd $(ROOTDIR) && tar cvz \
 		--dereference \
-		--transform s/qm/qm-input-${VERSION}/ \
-		-f /tmp/qm-input-${VERSION}.tar.gz \
+		--transform s/qm/${NV}/ \
+		-f /tmp/${NV}.tar.gz \
 		../qm/README.md \
 		../qm/SECURITY.md \
 		../qm/LICENSE \
 		../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_input.conf
-	cd $(ROOTDIR) && mv /tmp/qm-input-${VERSION}.tar.gz ./rpm
+	cd $(ROOTDIR) && mv /tmp/${NV}.tar.gz ./rpm
 
 .PHONY: input
 input:  dist ##             - Creates a local RPM package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cd $(ROOTDIR) && cp ./rpm/qm-input-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd $(ROOTDIR) && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_INPUT}
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi

--- a/subsystems/kvm/Makefile
+++ b/subsystems/kvm/Makefile
@@ -2,6 +2,8 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_IMG_KVM ?= ${ROOTDIR}/rpm/kvm/qm-kvm.spec
+PACKAGE_NAME = qm-kvm
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM kvm package
@@ -9,8 +11,8 @@ dist: ##             - Creates the QM kvm package
 		--dereference \
 		--transform 's|subsystems/kvm/Makefile|Makefile|' \
 		--transform 's|rpm/kvm/qm-kvm.spec|qm-kvm.spec|' \
-		--transform 's|qm|qm-kvm-${VERSION}|' \
-		-f /tmp/qm-kvm-${VERSION}.tar.gz \
+		--transform 's|qm|${NV}|' \
+		-f /tmp/${NV}.tar.gz \
 		../qm/rpm/kvm/qm-kvm.spec \
 		../qm/subsystems/kvm/Makefile \
 		../qm/tools/version-update \
@@ -21,15 +23,18 @@ dist: ##             - Creates the QM kvm package
 		../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_kvm.conf \
 		../qm/subsystems/kvm/etc/containers/systemd/kvm.container
 
-	cd ${ROOTDIR} && mv /tmp/qm-kvm-${VERSION}.tar.gz ./rpm
+	cd ${ROOTDIR} && mv /tmp/${NV}.tar.gz ./rpm
 
 .PHONY: kvm
 kvm: dist ##             - Creates a local RPM kvm package, useful for development
 	@echo ${VERSION}
 	cd ${ROOTDIR} && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
-	cd ${ROOTDIR} && cp ./rpm/qm-kvm-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd ${ROOTDIR} && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_IMG_KVM}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi

--- a/subsystems/radio/Makefile
+++ b/subsystems/radio/Makefile
@@ -2,27 +2,32 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_RADIO ?= ${ROOTDIR}/rpm/radio/radio.spec
+PACKAGE_NAME = qm-mount-bind-radio
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM radio package
 	cd $(ROOTDIR) && tar cvz \
 		--dereference \
-		--transform s/qm/qm-radio-${VERSION}/ \
-		-f /tmp/qm-radio-${VERSION}.tar.gz \
+		--transform s/qm/${NV}/ \
+		-f /tmp/${NV}.tar.gz \
 		../qm/README.md \
 		../qm/SECURITY.md \
 		../qm/LICENSE \
         ../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_radio.conf
-	cd $(ROOTDIR) && mv /tmp/qm-radio-${VERSION}.tar.gz ./rpm
+	cd $(ROOTDIR) && mv /tmp/${NV}.tar.gz ./rpm
 
 
 .PHONY: radio
 radio: dist ##             - Creates a local RPM package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cd $(ROOTDIR) && cp ./rpm/qm-radio-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd $(ROOTDIR) && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_RADIO}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi

--- a/subsystems/ros2/Makefile
+++ b/subsystems/ros2/Makefile
@@ -2,6 +2,8 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_ROS2_ROLLING ?= ${ROOTDIR}/rpm/ros2/ros2_rolling.spec
+PACKAGE_NAME = qm-ros2
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM ros2 package
@@ -9,8 +11,8 @@ dist: ##             - Creates the QM ros2 package
 		--dereference \
                 --transform 's|subsystems/ros2/Makefile|Makefile|' \
                 --transform 's|rpm/ros2/ros2_rolling.spec|ros2_rolling.spec|' \
-		--transform s/qm/qm-ros2-${VERSION}/ \
-		-f /tmp/qm-ros2-${VERSION}.tar.gz \
+		--transform s/qm/${NV}/ \
+		-f /tmp/${NV}.tar.gz \
                 ../qm/rpm/ros2/ros2_rolling.spec \
                 ../qm/subsystems/ros2/Makefile \
                 ../qm/tools/version-update \
@@ -26,9 +28,12 @@ dist: ##             - Creates the QM ros2 package
 ros2: dist ##          - Creates a local RPM package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cd $(ROOTDIR) && cp ./rpm/qm-ros2-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd $(ROOTDIR) && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_ROS2_ROLLING}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi

--- a/subsystems/sound/Makefile
+++ b/subsystems/sound/Makefile
@@ -2,6 +2,8 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_SOUND ?= ${ROOTDIR}/rpm/sound/sound.spec
+PACKAGE_NAME = qm-sound
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM sound package
@@ -9,8 +11,8 @@ dist: ##             - Creates the QM sound package
 		--dereference \
 		--transform 's|subsystems/kvm/Makefile|Makefile|' \
 		--transform 's|rpm/sound/sound.spec|qm-sound.spec|' \
-		--transform 's|qm|qm-sound-${VERSION}|' \
-		-f /tmp/qm-sound-${VERSION}.tar.gz \
+		--transform 's|qm|${NV}|' \
+		-f /tmp/${NV}.tar.gz \
 		../qm/rpm/sound/sound.spec \
 		../qm/subsystems/sound/Makefile \
 		../qm/tools/version-update \
@@ -20,15 +22,18 @@ dist: ##             - Creates the QM sound package
 		../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_snd.conf \
 		../qm/subsystems/sound/etc/containers/systemd/audio.container
 
-	cd $(ROOTDIR) && mv /tmp/qm-sound-${VERSION}.tar.gz ./rpm
+	cd $(ROOTDIR) && mv /tmp/${NV}.tar.gz ./rpm
 
 .PHONY: sound
 sound: dist ##             - Creates a local RPM package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cd $(ROOTDIR) && cp ./rpm/qm-sound-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd $(ROOTDIR) && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_SOUND}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi

--- a/subsystems/text2speech/Makefile
+++ b/subsystems/text2speech/Makefile
@@ -2,6 +2,8 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_TEXT2SPEECH ?= ${ROOTDIR}/rpm/text2speech/text2speech.spec
+PACKAGE_NAME = qm-text2speech
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM input package
@@ -9,8 +11,8 @@ dist: ##             - Creates the QM input package
 		--dereference \
                 --transform 's|subsystems/text2speech/Makefile|Makefile|' \
                 --transform 's|rpm/text2speech/text2speech.spec|text2speech.spec|' \
-		--transform s/qm/qm-text2speech-${VERSION}/ \
-		-f /tmp/qm-text2speech-${VERSION}.tar.gz \
+		--transform s/qm/${NV}/ \
+		-f /tmp/${NV}.tar.gz \
                 ../qm/rpm/text2speech/text2speech.spec \
                 ../qm/subsystems/text2speech/Makefile \
                 ../qm/tools/version-update \
@@ -19,14 +21,18 @@ dist: ##             - Creates the QM input package
 		../qm/CODE-OF-CONDUCT.md \
 		../qm/SECURITY.md \
 		../qm/LICENSE
-	cd $(ROOTDIR) && mv /tmp/qm-text2speech-${VERSION}.tar.gz ./rpm
+	cd $(ROOTDIR) && mv /tmp/${NV}.tar.gz ./rpm
 
 .PHONY: text2speech
 text2speech: dist ##            - Creates a local RPM package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cd $(ROOTDIR) && cp ./rpm/qm-text2speech-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd $(ROOTDIR) && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	cd $(ROOTDIR) && rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_TEXT2SPEECH}
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi

--- a/subsystems/tty7/Makefile
+++ b/subsystems/tty7/Makefile
@@ -2,6 +2,8 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_TTY7 ?= ${ROOTDIR}/rpm/tty7/tty7.spec
+PACKAGE_NAME = qm-mount-bind-tty7
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM tty7 package
@@ -9,8 +11,8 @@ dist: ##             - Creates the QM tty7 package
 		--dereference \
 		--transform 's|subsystems/tty7/Makefile|Makefile|' \
 		--transform 's|rpm/tty7/tty7.spec|tty7.spec|' \
-		--transform s/qm/qm-tty7-${VERSION}/ \
-		-f /tmp/qm-tty7-${VERSION}.tar.gz \
+		--transform s/qm/${NV}/ \
+		-f /tmp/${NV}.tar.gz \
                 ../qm/rpm/tty7/tty7.spec \
 		../qm/subsystems/tty7/Makefile \
 		../qm/tools/version-update \
@@ -19,15 +21,18 @@ dist: ##             - Creates the QM tty7 package
 		../qm/SECURITY.md \
 		../qm/LICENSE \
 		../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_tty7.conf
-	cd $(ROOTDIR) && mv /tmp/qm-tty7-${VERSION}.tar.gz ./rpm
+	cd $(ROOTDIR) && mv /tmp/${NV}.tar.gz ./rpm
 
 .PHONY: tty7
 tty7: dist ##             - Creates a local RPM package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cd $(ROOTDIR) && cp ./rpm/qm-tty7-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd $(ROOTDIR) && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_TTY7}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi

--- a/subsystems/ttyUSB0/Makefile
+++ b/subsystems/ttyUSB0/Makefile
@@ -2,15 +2,17 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_TTYUSB0 ?= ${ROOTDIR}/rpm/ttyUSB0/ttyUSB0.spec
+PACKAGE_NAME = qm-mount-bind-ttyUSB0
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM ttyUSB0 package
 	cd $(ROOTDIR) && tar cvz \
 		--dereference \
-		--transform s/qm/qm-ttyUSB0-${VERSION}/ \
+		--transform s/qm/${NV}/ \
 		--transform 's|subsystems/ttyUSB0/Makefile|Makefile|' \
 		--transform 's|rpm/ttyUSB0/ttyUSB0.spec|ttyUSB0.spec|' \
-		-f /tmp/qm-ttyUSB0-${VERSION}.tar.gz \
+		-f /tmp/${NV}.tar.gz \
 		../qm/rpm/ttyUSB0/ttyUSB0.spec \
 		../qm/subsystems/ttyUSB0/Makefile \
 		../qm/tools/version-update \
@@ -19,15 +21,18 @@ dist: ##             - Creates the QM ttyUSB0 package
 		../qm/SECURITY.md \
 		../qm/LICENSE \
 		../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_ttyUSB0.conf
-	cd $(ROOTDIR) && mv /tmp/qm-ttyUSB0-${VERSION}.tar.gz ./rpm
+	cd $(ROOTDIR) && mv /tmp/${NV}.tar.gz ./rpm
 
 .PHONY: ttyUSB0
 ttyUSB0: dist ##             - Creates a local RPM package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cd $(ROOTDIR) && cp ./rpm/qm-ttyUSB0-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd $(ROOTDIR) && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_TTYUSB0}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi

--- a/subsystems/video/Makefile
+++ b/subsystems/video/Makefile
@@ -2,6 +2,8 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_VIDEO ?= ${ROOTDIR}/rpm/video/video.spec
+PACKAGE_NAME = qm-mount-bind-video
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM video package
@@ -9,8 +11,8 @@ dist: ##             - Creates the QM video package
 		--dereference \
                 --transform 's|subsystems/video/Makefile|Makefile|' \
                 --transform 's|rpm/video/video.spec|video.spec|' \
-		--transform s/qm/qm-video-${VERSION}/ \
-		-f /tmp/qm-video-${VERSION}.tar.gz \
+		--transform s/qm/${NV}/ \
+		-f /tmp/${NV}.tar.gz \
 		../qm/rpm/video/video.spec \
                 ../qm/subsystems/video/Makefile \
                 ../qm/tools/version-update \
@@ -20,15 +22,18 @@ dist: ##             - Creates the QM video package
 		../qm/LICENSE \
 		../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_video.conf \
 		../qm/subsystems/video/etc/containers/systemd/rear-camera.container
-	cd $(ROOTDIR) && mv /tmp/qm-video-${VERSION}.tar.gz ./rpm
+	cd $(ROOTDIR) && mv /tmp/${NV}.tar.gz ./rpm
 
 .PHONY: video
 video: dist ##             - Creates a local RPM package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cd $(ROOTDIR) && cp ./rpm/qm-video-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cd $(ROOTDIR) && cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_VIDEO}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi

--- a/subsystems/windowmanager/Makefile
+++ b/subsystems/windowmanager/Makefile
@@ -2,6 +2,8 @@ RPM_TOPDIR ?= $(PWD)/rpmbuild
 VERSION ?= $(shell cat VERSION)
 ROOTDIR ?= $(PWD)
 SPECFILE_SUBPACKAGE_IMG_WINDOWMANAGER ?= ${ROOTDIR}/rpm/windowmanager/windowmanager.spec
+PACKAGE_NAME = qm-windowmanager
+NV ?= ${PACKAGE_NAME}-${VERSION}
 
 .PHONY: dist
 dist: ##             - Creates the QM windowmanager package
@@ -9,23 +11,26 @@ dist: ##             - Creates the QM windowmanager package
 		--dereference \
 		--transform 's|subsystems/windowmanager/Makefile|Makefile|' \
 		--transform 's|rpm/windowmanager/windowmanager.spec|windowmanager.spec|' \
-		--transform s/qm/qm-windowmanager-${VERSION}/ \
-		-f /tmp/qm-windowmanager-${VERSION}.tar.gz \
+		--transform s/qm/${NV}/ \
+		-f /tmp/${NV}.tar.gz \
 		../qm/README.md \
 		../qm/SECURITY.md \
 		../qm/LICENSE \
 		../qm/subsystems/windowmanager/etc/containers/systemd/ \
 		../qm/subsystems/windowmanager/etc/pam.d/wayland \
 		../qm/etc/containers/systemd/qm.container.d/qm_dropin_mount_bind_window_manager.conf
-	cd $(ROOTDIR) && mv /tmp/qm-windowmanager-${VERSION}.tar.gz ./rpm
+	cd $(ROOTDIR) && mv /tmp/${NV}.tar.gz ./rpm
 
 .PHONY: windowmanager
 windowmanager: dist ##         - Creates a local windowmanager package, useful for development
 	cd $(ROOTDIR) && mkdir -p ${RPM_TOPDIR}/{RPMS,SRPMS,BUILD,SOURCES}
 	cd $(ROOTDIR) && tools/version-update -v ${VERSION}
-	cp ./rpm/qm-windowmanager-${VERSION}.tar.gz ${RPM_TOPDIR}/SOURCES
+	cp ./rpm/${NV}.tar.gz ${RPM_TOPDIR}/SOURCES
 	rpmbuild -ba \
 		--define="_topdir ${RPM_TOPDIR}" \
 		--define="version ${VERSION}" \
 		${SPECFILE_SUBPACKAGE_IMG_WINDOWMANAGER}
-
+	if [ ! -f ${RPM_TOPDIR}/RPMS/noarch/${NV}*.noarch.rpm ]; then \
+		echo "RPM build failed"; \
+		exit 1; \
+	fi


### PR DESCRIPTION
Add explicit RPM existence checks after builds in subsystem Makefiles to ensure successful package creation and error handling where rpmbuild fails.